### PR TITLE
all: Restructured Makefiles to use JIVE_ROOT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,130 +2,29 @@
 # Copyright 2011 2012 2013 2014 2015 Nico Reißmann <nico.reissmann@gmail.com>
 # See COPYING for terms of redistribution.
 
-CPPFLAGS+=-Iinclude
+JIVE_ROOT ?= .
+
 CFLAGS+=-Wall -Wpedantic --std=c++14
+CPPFLAGS+=-I$(JIVE_ROOT)/include
 
-# RVSDG core
-LIBJIVE_SRC = \
-	src/common.c \
-	src/rvsdg/binary.c \
-	src/rvsdg/control.c \
-	src/rvsdg/equivalence.c \
-	src/rvsdg/gamma.c \
-	src/rvsdg/graph.c \
-	src/rvsdg/label.c \
-	src/rvsdg/negotiator.c \
-	src/rvsdg/node-normal-form.c \
-	src/rvsdg/node.c \
-	src/rvsdg/notifiers.c \
-	src/rvsdg/nullary.c \
-	src/rvsdg/operation.c \
-	src/rvsdg/phi.c \
-	src/rvsdg/region.c \
-	src/rvsdg/resource.c \
-	src/rvsdg/simple-normal-form.c \
-	src/rvsdg/simple-node.c \
-	src/rvsdg/statemux.c \
-	src/rvsdg/splitnode.c \
-	src/rvsdg/structural-normal-form.c \
-	src/rvsdg/structural-node.c \
-	src/rvsdg/theta.c \
-	src/rvsdg/tracker.c \
-	src/rvsdg/traverser.c \
-	src/rvsdg/type.c \
-	src/rvsdg/unary.c \
+.PHONY: all
+all: check
 
-#evaluation
-LIBJIVE_SRC += \
-	src/evaluator/eval.c \
-	src/evaluator/literal.c \
+include Makefile.sub
+include tests/Makefile.sub
 
-# visualization
-LIBJIVE_SRC += \
-	src/util/callbacks.c \
-	src/view.c \
-
-# bitstrings
-LIBJIVE_SRC += \
-	src/types/bitstring/arithmetic.c \
-	src/types/bitstring/bitoperation-classes.c \
-	src/types/bitstring/comparison.c \
-	src/types/bitstring/concat.c \
-	src/types/bitstring/constant.c \
-	src/types/bitstring/slice.c \
-	src/types/bitstring/type.c \
-	src/types/bitstring/value-representation.c \
-
-# floats
-LIBJIVE_SRC += \
-	src/types/float/arithmetic.c \
-	src/types/float/comparison.c \
-	src/types/float/fltconstant.c \
-	src/types/float/fltoperation-classes.c \
-	src/types/float/flttype.c \
-
-# records
-LIBJIVE_SRC += \
-	src/types/record.c \
-
-# unions
-LIBJIVE_SRC += \
-	src/types/union.c \
-
-# functions
-LIBJIVE_SRC += \
-	src/types/function.c \
-
-# arch definitions
-LIBJIVE_SRC += \
-	src/arch/address-transform.c \
-	src/arch/address.c \
-	src/arch/addresstype.c \
-	src/arch/call.c \
-	src/arch/compilate.c \
-	src/arch/dataobject.c \
-	src/arch/immediate.c \
-	src/arch/instruction.c \
-	src/arch/instructionset.c \
-	src/arch/label-mapper.c \
-	src/arch/load.c \
-	src/arch/memlayout-simple.c \
-	src/arch/memlayout.c \
-	src/arch/registers.c \
-	src/arch/regselector.c \
-	src/arch/regvalue.c \
-	src/arch/sizeof.c \
-	src/arch/stackslot.c \
-	src/arch/store.c \
-	src/arch/subroutine.c \
-	src/arch/subroutine/nodes.c \
-
-include src/backend/i386/Makefile.sub
-
-SOURCES += $(LIBJIVE_SRC)
-
-all: check libjive.a # libjive.so
-
-HEADERS = $(shell find include -name "*.h")
-
-libjive.a: $(patsubst %.c, %.la, $(LIBJIVE_SRC))
-libjive.so: $(patsubst %.c, %.lo, $(LIBJIVE_SRC))
-
+.PHONY: doc
 doc:
 	doxygen doxygen.conf
 
-clean: depclean
-	find . -name *.o -o -name *.lo -o -name *.la -o -name *.so -o -name *.a | xargs rm -rf
-	rm -rf $(TESTPROGS)
-	rm -rf a.out
-
-include tests/Makefile.sub
-
-%.la: %.c
-	$(CXX) -c $(CFLAGS) $(CPPFLAGS) -o $@ $<
+.PHONY: clean
+clean: jive-clean jive-test-clean
 
 %.lo: %.c
 	$(CXX) -c -DPIC -fPIC $(CFLAGS) $(CPPFLAGS) -o $@ $<
+
+%.la: %.c
+	$(CXX) -c $(CFLAGS) $(CPPFLAGS) -o $@ $<
 
 %.a:
 	rm -f $@
@@ -144,16 +43,11 @@ include tests/Makefile.sub
 	@mkdir -p $(dir $@)
 	@$(CXX) -MM -DPIC -fPIC $(CFLAGS) $(CPPFLAGS) -MT $(<:.c=.lo) -MP -MF $@ $<
 
-depclean:
-	rm -rf .dep
-
 DEPEND = $(patsubst %.c, .dep/%.la.d, $(SOURCES)) $(patsubst %.c, .dep/%.lo.d, $(SOURCES))
 depend: $(DEPEND)
 ifeq ($(shell if [ -e .dep ] ; then echo yes ; fi),yes)
 -include $(DEPEND)
 endif
-
-.PHONY: doc
 
 ifeq ($(shell if [ -e .Makefile.override ] ; then echo yes ; fi),yes)
 include .Makefile.override

--- a/Makefile.sub
+++ b/Makefile.sub
@@ -1,0 +1,117 @@
+# RVSDG core
+LIBJIVE_SRC = \
+	src/common.c \
+	src/rvsdg/binary.c \
+	src/rvsdg/control.c \
+	src/rvsdg/equivalence.c \
+	src/rvsdg/gamma.c \
+	src/rvsdg/graph.c \
+	src/rvsdg/label.c \
+	src/rvsdg/negotiator.c \
+	src/rvsdg/node-normal-form.c \
+	src/rvsdg/node.c \
+	src/rvsdg/notifiers.c \
+	src/rvsdg/nullary.c \
+	src/rvsdg/operation.c \
+	src/rvsdg/phi.c \
+	src/rvsdg/region.c \
+	src/rvsdg/resource.c \
+	src/rvsdg/simple-normal-form.c \
+	src/rvsdg/simple-node.c \
+	src/rvsdg/statemux.c \
+	src/rvsdg/splitnode.c \
+	src/rvsdg/structural-normal-form.c \
+	src/rvsdg/structural-node.c \
+	src/rvsdg/theta.c \
+	src/rvsdg/tracker.c \
+	src/rvsdg/traverser.c \
+	src/rvsdg/type.c \
+	src/rvsdg/unary.c \
+
+#evaluation
+LIBJIVE_SRC += \
+	src/evaluator/eval.c \
+	src/evaluator/literal.c \
+
+# visualization
+LIBJIVE_SRC += \
+	src/util/callbacks.c \
+	src/view.c \
+
+# bitstrings
+LIBJIVE_SRC += \
+	src/types/bitstring/arithmetic.c \
+	src/types/bitstring/bitoperation-classes.c \
+	src/types/bitstring/comparison.c \
+	src/types/bitstring/concat.c \
+	src/types/bitstring/constant.c \
+	src/types/bitstring/slice.c \
+	src/types/bitstring/type.c \
+	src/types/bitstring/value-representation.c \
+
+# floats
+LIBJIVE_SRC += \
+	src/types/float/arithmetic.c \
+	src/types/float/comparison.c \
+	src/types/float/fltconstant.c \
+	src/types/float/fltoperation-classes.c \
+	src/types/float/flttype.c \
+
+# records
+LIBJIVE_SRC += \
+	src/types/record.c \
+
+# unions
+LIBJIVE_SRC += \
+	src/types/union.c \
+
+# functions
+LIBJIVE_SRC += \
+	src/types/function.c \
+
+# arch definitions
+LIBJIVE_SRC += \
+	src/arch/address-transform.c \
+	src/arch/address.c \
+	src/arch/addresstype.c \
+	src/arch/call.c \
+	src/arch/compilate.c \
+	src/arch/dataobject.c \
+	src/arch/immediate.c \
+	src/arch/instruction.c \
+	src/arch/instructionset.c \
+	src/arch/label-mapper.c \
+	src/arch/load.c \
+	src/arch/memlayout-simple.c \
+	src/arch/memlayout.c \
+	src/arch/registers.c \
+	src/arch/regselector.c \
+	src/arch/regvalue.c \
+	src/arch/sizeof.c \
+	src/arch/stackslot.c \
+	src/arch/store.c \
+	src/arch/subroutine.c \
+	src/arch/subroutine/nodes.c \
+
+include $(JIVE_ROOT)/src/backend/i386/Makefile.sub
+
+SOURCES += $(LIBJIVE_SRC)
+
+HEADERS = $(shell find 	$(JIVE_ROOT)/include -name "*.h")
+
+
+.PHONY: jive
+jive: $(JIVE_ROOT)/libjive.a
+
+$(JIVE_ROOT)/libjive.a: $(patsubst %.c, $(JIVE_ROOT)/%.la, $(LIBJIVE_SRC))
+
+$(JIVE_ROOT)/libjive.so: $(patsubst %.c, $(JIVE_ROOT)/%.lo, $(LIBJIVE_SRC))
+
+.PHONY: jive-clean
+jive-clean: jive-depclean
+	@find $(JIVE_ROOT)/ -name "*.o" -o -name "*.lo" -o -name "*.la" -o -name "*.so" -o -name "*.a" | xargs rm -rf
+	@rm -rf $(JIVE_ROOT)/a.out
+
+.PHONY: jive-depclean
+jive-depclean:
+	@rm -rf $(JIVE_ROOT)/.dep

--- a/tests/Makefile.sub
+++ b/tests/Makefile.sub
@@ -20,8 +20,14 @@ $(patsubst %, .dep/tests/%.lo.d, $(TESTS)): CPPFLAGS+=-Itests
 
 TESTLOG=true
 
+# Font colors for terminal
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+.PHONY: check
 check: tests/test-runner
-	rm -rf check.log passed.log failed.log
+	@rm -rf check.log passed.log failed.log
 	@for TEST in `tests/test-runner`; do \
 		$(TESTLOG) -n "$$TEST: " ; \
 		if tests/test-runner $$TEST >>check.log 2>&1 ; then \
@@ -32,16 +38,19 @@ check: tests/test-runner
 	done
 	@if [ -e failed.log ] ; then \
 		if [ -z ${EXPECT_FAIL_TESTS+x} ] ; then \
-			echo "Failed:" ; \
+			echo $(Red)Failed:$(NC) ; \
 			cat failed.log ; \
 		else \
 			grep -v $(EXPECT_FAIL_TESTS) < failed.log | sed -e "s/^/Failed: /" ; \
 		fi \
+        else \
+		echo $(GREEN)All tests passed$(NC) ; \
 	fi
 	@if [ "x$(EXPECT_FAIL_TESTS)" != x ] ; then echo "Expected failures: $(EXPECT_FAIL_TESTS)" ; fi
 
+.PHONY: valgrind-check
 valgrind-check: tests/test-runner
-	rm -rf check.log passed.log failed.log
+	@rm -rf check.log passed.log failed.log
 	@for TEST in `tests/test-runner`; do \
 		$(TESTLOG) -n "$$TEST: " ; \
 		if valgrind --leak-check=full --error-exitcode=1 tests/test-runner $$TEST >>check.log 2>&1 ; then \
@@ -59,3 +68,7 @@ valgrind-check: tests/test-runner
 		fi \
 	fi
 	@if [ "x$(EXPECT_FAIL_TESTS)" != x ] ; then echo "Expected failures: $(EXPECT_FAIL_TESTS)" ; fi
+
+.PHONY: jive-test-clean
+jive-test-clean:
+	@rm -rf $(TESTPROGS)


### PR DESCRIPTION
Moving the fundamental targets to a Makefile.sub makes it possible to now include this file from a separate Makefile.
E.g., the Makefile in jlm could simply include external/jive/Makefile.sub and use jive as a dependency to automatically compile the jive library when needed.