### PR TITLE
all: Removed all remaining llvm ang gcc warnings during compilation

### DIFF
--- a/src/arch/address-transform.cpp
+++ b/src/arch/address-transform.cpp
@@ -324,8 +324,9 @@ transform_address(jive::node * node, memlayout_mapper & mapper)
 	, {typeid(apply_op), transform_apply}
 	});
 
-	if (map.find(typeid(node->operation())) != map.end())
-		map[typeid(node->operation())](node, mapper);
+	const auto & op = node->operation();
+	if (map.find(typeid(op)) != map.end())
+		map[typeid(op)](node, mapper);
 }
 
 void

--- a/src/backend/i386/instructionset.cpp
+++ b/src/backend/i386/instructionset.cpp
@@ -59,7 +59,7 @@ jive_i386_check_long_form(
 	jive_instruction_encoding_flags * flags,
 	jive_immediate_int offset)
 {
-	bool need_long_form;
+	bool need_long_form = false;
 	
 	switch (imm->info) {
 		case jive_codegen_imm_info_dynamic_known:

--- a/src/evaluator/eval.cpp
+++ b/src/evaluator/eval.cpp
@@ -425,9 +425,10 @@ eval_node(const jive::node * node, size_t index, context & ctx)
 	JIVE_DEBUG_ASSERT(index < node->noutputs());
 
 	/* check for special nodes and evaluate them */
-	if (evlmap.find(typeid(node->operation())) != evlmap.end()) {
+	const auto & op = node->operation();
+	if (evlmap.find(typeid(op)) != evlmap.end()) {
 		std::unique_ptr<const literal> result;
-		result = evlmap[typeid(node->operation())](node, index, ctx)->copy();
+		result = evlmap[typeid(op)](node, index, ctx)->copy();
 		return result;
 	}
 
@@ -437,7 +438,7 @@ eval_node(const jive::node * node, size_t index, context & ctx)
 		operands.emplace_back(eval_input(node->input(n), ctx));
 
 	std::vector<std::unique_ptr<const literal>> results;
-	results = compute_operation(node->operation(), operands);
+	results = compute_operation(op, operands);
 
 	JIVE_DEBUG_ASSERT(results.size() == node->noutputs());
 	for (size_t n = 0; n < node->noutputs(); n++)

--- a/src/rvsdg/binary.cpp
+++ b/src/rvsdg/binary.cpp
@@ -271,9 +271,10 @@ bool
 flattened_binary_normal_form::normalize_node(jive::node * node) const
 {
 	const auto & op = static_cast<const flattened_binary_op&>(node->operation());
-	auto nf = graph()->node_normal_form(typeid(op.bin_operation()));
+	const auto & bin_op = op.bin_operation();
+	auto nf = graph()->node_normal_form(typeid(bin_op));
 
-	return static_cast<const binary_normal_form *>(nf)->normalize_node(node, op.bin_operation());
+	return static_cast<const binary_normal_form *>(nf)->normalize_node(node, bin_op);
 }
 
 std::vector<jive::output*>
@@ -283,10 +284,11 @@ flattened_binary_normal_form::normalized_create(
 	const std::vector<jive::output*> & arguments) const
 {
 	const auto & op = static_cast<const flattened_binary_op&>(base_op);
+	const auto & bin_op = op.bin_operation();
 
 	auto nf = static_cast<const binary_normal_form*>(
-		graph()->node_normal_form(typeid(op.bin_operation())));
-	return nf->normalized_create(region, op.bin_operation(), arguments);
+		graph()->node_normal_form(typeid(bin_op)));
+	return nf->normalized_create(region, bin_op, arguments);
 }
 
 /* binary operator */

--- a/src/rvsdg/gamma.cpp
+++ b/src/rvsdg/gamma.cpp
@@ -129,7 +129,7 @@ perform_control_constant_reduction(std::unordered_set<jive::structural_output*> 
 		if (outputs.find(xv.output()) == outputs.end())
 			continue;
 
-		size_t defalt;
+		size_t defalt = 0;
 		std::unordered_map<uint64_t, uint64_t> new_mapping;
 		for (size_t n = 0; n < xv->nresults(); n++) {
 			auto origin = static_cast<node_output*>(xv->result(n)->origin());

--- a/src/rvsdg/node.cpp
+++ b/src/rvsdg/node.cpp
@@ -313,7 +313,8 @@ producer(const jive::output * output) noexcept
 bool
 normalize(jive::node * node)
 {
-	auto nf = node->graph()->node_normal_form(typeid(node->operation()));
+	const auto & op = node->operation();
+	auto nf = node->graph()->node_normal_form(typeid(op));
 	return nf->normalize_node(node);
 }
 

--- a/src/rvsdg/phi.cpp
+++ b/src/rvsdg/phi.cpp
@@ -16,7 +16,7 @@ namespace phi {
 
 /* phi operation class */
 
-operation::~operation() noexcept
+operation::~operation()
 {}
 
 std::string

--- a/src/rvsdg/region.cpp
+++ b/src/rvsdg/region.cpp
@@ -268,7 +268,8 @@ region::normalize(bool recursive)
 				structnode->subregion(n)->normalize(recursive);
 		}
 
-		graph()->node_normal_form(typeid(node->operation()))->normalize_node(node);
+		const auto & op = node->operation();
+		graph()->node_normal_form(typeid(op))->normalize_node(node);
 	}
 }
 


### PR DESCRIPTION
Most warnings were for LLVM, which have been avoided by declaring a variable instead of using a function-call as the argument to another function, e.g., typeid().
There were also two variables that didn't have a default value defined, which gcc complained about.

Checks both for jive and jlm, as well as polybench-compare, works.