### PR TITLE
Improve copy behavior

### DIFF
--- a/src/rvsdg/region.cpp
+++ b/src/rvsdg/region.cpp
@@ -225,7 +225,7 @@ region::copy(
 	/* copy nodes */
 	for (size_t n = 0; n < context.size(); n++) {
 		for (const auto node : context[n]) {
-            JIVE_ASSERT(target == smap.lookup(node->region()));
+			JIVE_ASSERT(target == smap.lookup(node->region()));
 			node->copy(target, smap);
 		}
 	}

--- a/src/rvsdg/region.cpp
+++ b/src/rvsdg/region.cpp
@@ -225,7 +225,7 @@ region::copy(
 	/* copy nodes */
 	for (size_t n = 0; n < context.size(); n++) {
 		for (const auto node : context[n]) {
-			target = smap.lookup(node->region());
+            JIVE_ASSERT(target == smap.lookup(node->region()));
 			node->copy(target, smap);
 		}
 	}

--- a/src/rvsdg/simple-node.cpp
+++ b/src/rvsdg/simple-node.cpp
@@ -83,8 +83,16 @@ simple_node::copy(jive::region * region, jive::substitution_map & smap) const
 {
 	std::vector<jive::output*> operands;
 	for (size_t n = 0; n < ninputs(); n++) {
-		auto operand = smap.lookup(input(n)->origin());
-		operands.push_back(operand ? operand : input(n)->origin());
+	    auto origin = input(n)->origin();
+		auto operand = smap.lookup(origin);
+		if(!operand){
+		    if(region == this->region()){
+		        operand = origin;
+		    } else{
+                throw compiler_error("Node operand not in substitution map.");
+		    }
+		}
+		operands.push_back(operand);
 	}
 
 	auto node = copy(region, operands);

--- a/src/rvsdg/simple-node.cpp
+++ b/src/rvsdg/simple-node.cpp
@@ -83,14 +83,14 @@ simple_node::copy(jive::region * region, jive::substitution_map & smap) const
 {
 	std::vector<jive::output*> operands;
 	for (size_t n = 0; n < ninputs(); n++) {
-	    auto origin = input(n)->origin();
+		auto origin = input(n)->origin();
 		auto operand = smap.lookup(origin);
-		if(!operand){
-		    if(region == this->region()){
-		        operand = origin;
-		    } else{
-                throw compiler_error("Node operand not in substitution map.");
-		    }
+		if (!operand) {
+			if (region == this->region()) {
+				operand = origin;
+			} else{
+				throw compiler_error("Node operand not in substitution map.");
+			}
 		}
 		operands.push_back(operand);
 	}


### PR DESCRIPTION
simple_node::copy defaults to using the origin of an operand directly when it can not be found in the substitution map.
I think this is only valid behavior when the region that is being copied into is the region the node is already in and otherwise already leads to a (harder to trace) error in the constructor of input.
region::copy seems to look up the region of each node in the region, overwriting the target permanently.
AFAICT a node in a region should always belong to that region, making the substitution pointless.

I am also wondering why region::copy manually creates a depth based context order instead of using jive::topdown_traverser.
Is it in order to allow copying into the same region?